### PR TITLE
chore: Update Fedora Dockerfile and build workflow

### DIFF
--- a/.devcontainer/Dockerfile-Fedora
+++ b/.devcontainer/Dockerfile-Fedora
@@ -1,0 +1,28 @@
+
+FROM fedora:latest
+
+RUN yum install -y "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm" && \
+yum install -y "https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-9.noarch.rpm"
+
+# RUN sed -i 's/\(def in_container():\)/\1\n    return False/g' /usr/lib64/python*/*-packages/rhsm/config.py
+RUN yum update -y && yum install bash gdb strace git yum-utils -y
+# Install development tools and createrepo
+RUN yum -y update && \
+    yum -y install \
+    gcc \
+    gcc-c++ \
+    make 
+
+# Clean up Yum cache
+RUN yum clean all
+
+# Create a non-root user and add sudo support
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN yum update -y && yum install git sudo wget zsh -y
+RUN groupadd -g 911 sudo
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+USER vscode

--- a/.github/workflows/build-fedora.yml
+++ b/.github/workflows/build-fedora.yml
@@ -1,0 +1,37 @@
+name: Build and Push Fedora Images
+
+# Schedule the workflow to run daily at 00:00 UTC
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  contents: read
+  packages: write
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: ./.devcontainer
+          file: ./.devcontainer/Dockerfile-Fedora
+          push: true
+          
+          tags: ghcr.io/${{ github.repository_owner }}/devcontainer-rhelyeah:fedora-latest
+
+      - name: Post build cleanup
+        run: docker system prune -f


### PR DESCRIPTION
This pull request includes changes to set up a Fedora-based development environment using Docker and automate the build and push process with GitHub Actions. The most important changes include the addition of a Dockerfile for Fedora and a GitHub Actions workflow to build and push the Docker image.

### Fedora-based Development Environment Setup:

* [`.devcontainer/Dockerfile-Fedora`](diffhunk://#diff-cbc16644527ccbb61bcff18292008727aad2b9ae01693bfcdfb764680dd3a2edR1-R28): Added a Dockerfile to set up a Fedora-based development environment, including installing necessary development tools and creating a non-root user with sudo privileges.

### GitHub Actions Workflow:

* [`.github/workflows/build-fedora.yml`](diffhunk://#diff-3c49a3460baee3f2373e4957fcc0dd008385c215870dab252af2416902a7f357R1-R37): Added a GitHub Actions workflow to build and push the Fedora Docker image daily at 00:00 UTC. This workflow includes steps for checking out the repository, setting up Docker Buildx, logging into the GitHub Container Registry, building and pushing the Docker image, and performing post-build cleanup.